### PR TITLE
chore(dotfiles): update local workspace config

### DIFF
--- a/home/AGENTS.md
+++ b/home/AGENTS.md
@@ -53,9 +53,12 @@ ALWAYS use subagents where possible, prefer to parallelize work when it does not
 - Do not add project-specific prefixes to all environment variables by default; for external services, prefer the service's conventional names (e.g. `HOME_ASSISTANT_URL`) unless the project explicitly uses a different convention.
 - When the user scopes cleanup to a deployment/platform (for example Kubernetes), do not remove or modify similarly named resources in other platforms (Nomad, Ansible, Terraform, etc.) unless explicitly requested.
 - When applying Talos machine config to multiple control-plane nodes, apply and verify one node at a time; never trigger simultaneous control-plane reboots unless explicitly planned and approved.
+- Before confirming a user's hypothesis about where behavior lives or how code works, verify it against the repository and cite the evidence; do not blindly agree.
 
 ### Pi agent
 - Pi config lives in ~/dev/pi-config (separate repo, all pi agent configuration should be done there)
 - Never edit `~/.pi/agent/*` directly when the file is managed by `~/dev/pi-config`; update the source repo first.
 - For Pi config changes, prefer the repo's own apply flow (`cd ~/dev/pi-config && just apply`) instead of writing rendered files by hand.
 - In Pi `models.json`, custom providers with models require a non-empty `apiKey`; for local OpenAI-compatible servers, use a dummy value like `"ollama"`/`"llama-server"`, not an empty string.
+- When detecting whether a Pi process is a child spawned by `pi-subagents`, use the current `pi-subagents` runtime contract (`PI_SUBAGENT_CHILD=1`) rather than older environment names like `PI_SUBAGENT_NAME`.
+- In pi-config code, prefer the shared `isSubagent()` helper over checking `PI_SUBAGENT_CHILD` directly.

--- a/home/dot_config/fnox/config.toml.tmpl
+++ b/home/dot_config/fnox/config.toml.tmpl
@@ -6,6 +6,7 @@
 type = "age"
 recipients = ["age1q6el4a8vtj0uyzt7447m43mp887z28eqvhmfs3a5nl383wxhpf9szjj9jc"]
 
+{{ if ne .environment "work" }}
 [providers.op]
 type = "1password"
 
@@ -15,3 +16,4 @@ GEMINI_API_KEY = { provider = "op", value = "op://dotenv/GEMINI_API_KEY/value" }
 OPENAI_API_KEY = { provider = "op", value = "op://dotenv/OPENAI_API_KEY/value" }
 OPENROUTER_API_KEY = { provider = "op", value = "op://dotenv/OPENROUTER_API_KEY/value" }
 FIREWORKS_API_KEY = { provider = "op", value = "op://dotenv/FIREWORKS_API_KEY/value" }
+{{ end }}

--- a/home/dot_config/ghostty/config
+++ b/home/dot_config/ghostty/config
@@ -1,5 +1,4 @@
-theme = "light:Flexoki Light,dark:Rose Pine Moon"
-theme = ""
+#theme = "light:Flexoki Light,dark:Rose Pine Moon"
 theme = "Rose Pine Moon"
 cursor-color = "#ffffff"
 

--- a/home/dot_config/zellij/layouts/privy.kdl
+++ b/home/dot_config/zellij/layouts/privy.kdl
@@ -74,4 +74,24 @@ layout {
       }
     }
 
+    tab name="pi-config" cwd="~/dev/pi-config" hide_floating_panes=true {
+      pane command="pi"
+      pane
+      floating_panes {
+          pane {
+              x "25%"
+              y "5%"
+              width "50%"
+              height "50%"
+          }
+          pane {
+              command "gitui"
+              x "10%"
+              y "10%"
+              width "80%"
+              height "80%"
+          }
+      }
+    }
+
 }


### PR DESCRIPTION
Update the persisted agent guidance, render Fnox config as a chezmoi template, simplify the Ghostty theme selection, and add a pi-config tab to the Privy Zellij layout.